### PR TITLE
Refactor:  bytes

### DIFF
--- a/Set_1.ipynb
+++ b/Set_1.ipynb
@@ -1186,6 +1186,161 @@
    "source": [
     "The chances of a hex-encoded string having a 16-byte repeat, randomly, is absolutely tiny, so this should be our match! Taking this to be true, we can move on to set 2, where we will in fact learn how to crack ECB encrypted messages, at which point we can come back here and hopefully check our work."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Appendix A: *Bytes in Python*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To the uninitiated, the *bytes* type in Python can be a little confusing. Turning a string into a *bytes* type is easy:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 131,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "b'Hello World!' <class 'bytes'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "bytes_example = \"Hello World!\".encode()\n",
+    "print(bytes_example, type(bytes_example))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Naively, the string just picks up this preceding '**b**', which can be used to initialise *bytes*, too. This object now behaves loosely like a string, in that addition and multiplication simply append other *bytes* to the object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 132,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "b'Hello World! What a wonderful life!'\n",
+      "b'HaHaHaHaHa'\n"
+     ]
+    }
+   ],
+   "source": [
+    "bytes_example += b\" What a wonderful life!\"\n",
+    "print(bytes_example)\n",
+    "print(b\"Ha\" * 5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Difficult arises in trying to perform logical operations on *bytes* objects, which aren't defined:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 133,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "unsupported operand type(s) for ^: 'bytes' and 'bytes'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32mc:\\Users\\whatf\\OneDrive\\Desktop\\Cryptopals-lite\\Set_1.ipynb Cell 83\u001b[0m in \u001b[0;36m<cell line: 1>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> <a href='vscode-notebook-cell:/c%3A/Users/whatf/OneDrive/Desktop/Cryptopals-lite/Set_1.ipynb#Y216sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m \u001b[39mb\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mHello\u001b[39;49m\u001b[39m\"\u001b[39;49m \u001b[39m^\u001b[39;49m \u001b[39mb\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mWorld\u001b[39;49m\u001b[39m\"\u001b[39;49m\n",
+      "\u001b[1;31mTypeError\u001b[0m: unsupported operand type(s) for ^: 'bytes' and 'bytes'"
+     ]
+    }
+   ],
+   "source": [
+    "b\"Hello\" ^ b\"World\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Yes*, this is frustrating. However, we can quickly see that under the hood, *bytes* are not exactly what they seem:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 134,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[72, 101, 108, 108, 111]"
+      ]
+     },
+     "execution_count": 134,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "list(b\"Hello\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In fact, *bytes* are just integer lists, where each spot in the list is occupied by a number between 0 and 255 (no big prizes for guessing why). Then, the *bytes* class's real talent is just taking an integer list, and pretty-printing whenever it can the *utf-8* encodings corresponding to the given element.\n",
+    "\n",
+    "As such, we now have a very easy way to generate the logical XOR of two *bytes* buffers:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 135,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'\\x1f\\n\\x1e\\x00\\x0b'"
+      ]
+     },
+     "execution_count": 135,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bytes([a ^ b for a, b in zip(b\"Hello\", b\"World\")])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note there are faster ways to implement this, but this is probably the simplest and most Pythonic. As we can now get back on with the cryptography.\n",
+    "\n",
+    "**TL; DR**:\n",
+    "- *Bytes* objects are integer lists which Python encodes in the __repr__ dunder so that they display either as ascii characters, or hexadecimal numbers.\n",
+    "- As such, they behave as lists with slicing and addition/multiplication.\n",
+    "- Generating the logical XOR (or other logical operations) of the *bytes* is done using list comprehension: operrating on the integer elements, and then converting back into *bytes*."
+   ]
   }
  ],
  "metadata": {

--- a/functions.py
+++ b/functions.py
@@ -42,7 +42,7 @@ def eq_buffer_XOR(a: bytes, b: bytes) -> bytes:
     return bytes([i^j for i, j in zip(a, b)])
 
 def pad_buffer(buffer: bytes, pad: bytes, length: int) -> bytes:
-    return pad * l + b
+    return pad * length + buffer
 
 def hex_XOR(s: str, t: str) -> str:
     """

--- a/functions.py
+++ b/functions.py
@@ -7,25 +7,25 @@ from scipy.stats import chisquare
 from numpy import inf
 from hexhamming import hamming_distance_string
 
-def to_bytes(s: str, encoding: str = "hex") -> List[str]:
+def to_bytes(s: str, encoding: str = "hex") -> bytes:
     match encoding:
         case "hex":
-            return [hex(i) for i in bytes.fromhex(s)]
+            return base64.b16decode(s, casefold=True)
         case "b64":
-            return [hex(i) for i in base64.b64decode(s)]
+            return base64.b64decode(s, casefold=True)
         case "plaintext":
-            return [hex(i) for i in s.encode()]
+            return s.encode()
         case _:
             raise ValueError("Encoding not recognised.")
 
-def to_plaintext(b: List[str]) -> str:
-    return "".join([bytes.fromhex("0" * (2-len(i[2:])) + i[2:]).decode() for i in b])
+def to_plaintext(b: bytes) -> str:
+    return b.decode()
 
-def to_hex(b: List[str]) -> str:
-    return "".join("0" * (2-len(i[2:])) + i[2:] for i in b)
+def to_hex(b: bytes) -> str:
+    return base64.b16encode(b).decode().lower()
 
-def to_b64(b: List[str]) -> str:
-    return base64.b64encode(bytes.fromhex(to_hex(b))).decode()
+def to_b64(b: bytes) -> str:
+    return base64.b64encode(b).decode()
 
 def encode_output(buffer: List[str], encoding="hex"):
 
@@ -34,22 +34,32 @@ def encode_output(buffer: List[str], encoding="hex"):
     
     return output_dict[encoding]
 
+def eq_buffer_XOR(a: bytes, b: bytes) -> bytes:
+    """
+    Take 2 equal length buffers and return their logical XOR.
+    """
+    assert len(a) == len(b), "Byte buffers must be of equal length."
+    return bytes([i^j for i, j in zip(a, b)])
+
+def pad_buffer(buffer: bytes, pad: bytes, length: int) -> bytes:
+    return pad * l + b
+
 def hex_XOR(s: str, t: str) -> str:
     """
     Take 2 hex-encoded bytes and return the hex-encoded byte corresponding to their logical XOR.
     """
     return hex(int(s, 16) ^ int(t, 16))
 
-def key_XOR(buffer: List[str], key: List[str]) -> List[str]:
-    return  [hex_XOR(p, k) for p, k in zip(buffer, cycle(key))]
+def key_XOR(buffer: bytes, key: bytes) -> bytes:
+    return  bytes([p ^ k for p, k in zip(buffer, cycle(key))])
 
-def byte_XOR_encrypt(s: str, c: str, output_encoding="b64") -> str:
+def byte_XOR_encrypt(s: str, c: bytes, output_encoding="b64") -> str:
     """
-    Encrypts 's', a plaintext string, using the single byte key, 'c'. 'c' should be passed as a string-represented hexadecimal number between 0 and 255, inclusive, obviously.
+    Encrypts 's', a plaintext string, using the single byte key, 'c'.
     """
     string_buffer = to_bytes(s, 'plaintext')
     
-    output_buffer = key_XOR(string_buffer, [c])
+    output_buffer = key_XOR(string_buffer, c)
     
     return encode_output(output_buffer, output_encoding)
 
@@ -57,7 +67,7 @@ def byte_XOR_decrypt(s: str, c: str, input_encoding="b64") -> str:
     
     cipher_buffer = to_bytes(s, input_encoding)
 
-    output_buffer = key_XOR(cipher_buffer, [c])
+    output_buffer = key_XOR(cipher_buffer, c)
 
     return to_plaintext(output_buffer)
 

--- a/functions.py
+++ b/functions.py
@@ -41,8 +41,14 @@ def eq_buffer_XOR(a: bytes, b: bytes) -> bytes:
     assert len(a) == len(b), "Byte buffers must be of equal length."
     return bytes([i^j for i, j in zip(a, b)])
 
-def pad_buffer(buffer: bytes, pad: bytes, length: int) -> bytes:
-    return pad * length + buffer
+def pad_buffer(buffer: bytes, pad: bytes, length: int, end='back') -> bytes:
+    match end:
+        case 'front':
+            return pad * length + buffer
+        case 'back':
+            return buffer + pad * length
+        case _:
+            raise ValueError("End must be 'front' or 'back'.")
 
 def hex_XOR(s: str, t: str) -> str:
     """
@@ -141,16 +147,4 @@ def crack_key_length(c: str, max_length=100) -> int:
     pass
 
 if __name__ == "__main__":
-    string = """1D421F4D0B0F021F4F134E3C1A69651F491C0E4E13010B074E1B01164536001E01496420541D1D4333534E6552060047541C"""
-    with open('lotr.txt', 'r') as lotr:
-        lines_to_read = 1000
-        text = ""
-        for line in lotr:
-            lines_to_read -= 1
-            if lines_to_read < 0:
-                break
-            else:
-                for char in line:
-                    text += char
-
-    print(norm_hamming_dist(to_hex(to_bytes(text, 'plaintext')), 1))
+    print(pad_buffer(b"YELLOW SUBMARINE", b'\x04', 4))

--- a/functions_test.py
+++ b/functions_test.py
@@ -1,9 +1,11 @@
 from functions import *
 
 def test_conversion():
-    assert to_bytes('Hello', 'plaintext') == ['0x48', '0x65', '0x6c', '0x6c', '0x6f']
+    assert to_bytes('Hello', 'plaintext') == b"Hello"
     assert to_plaintext(to_bytes('Hello', 'plaintext')) == 'Hello'
     assert to_hex(to_bytes('48656c6c6f', 'hex')) == '48656c6c6f'
+    for i in range(1, 255):
+        assert int(to_plaintext(to_bytes(str(i), 'plaintext'))) == i
     assert to_b64(to_bytes('49276d206b696c6c696e6720796f757220627261696e206c696b65206120706f69736f6e6f7573206d757368726f6f6d', 'hex')) == 'SSdtIGtpbGxpbmcgeW91ciBicmFpbiBsaWtlIGEgcG9pc29ub3VzIG11c2hyb29t'
     """
     As that test passed, we have also passed Task 1 of the Cryptopals challenges!
@@ -12,7 +14,7 @@ def test_conversion():
 def test_XOR():
     buffer1 = to_bytes('1c0111001f010100061a024b53535009181c')
     buffer2 = to_bytes('686974207468652062756c6c277320657965')
-    XOR_product = [hex_XOR(a, b) for a, b in zip(buffer1, buffer2)]
+    XOR_product = eq_buffer_XOR(buffer1, buffer2)
     assert to_hex(XOR_product) == '746865206b696420646f6e277420706c6179'
     """
     That's Task 2!
@@ -21,7 +23,7 @@ def test_XOR():
 def test_sbXOR():
     plaintext = "Cooking MC's like a pound of bacon"
     key = "X"
-    assert byte_XOR_encrypt(plaintext, hex(ord(key)), output_encoding="hex") == "1b37373331363f78151b7f2b783431333d78397828372d363c78373e783a393b3736"
+    assert byte_XOR_encrypt(plaintext, key.encode(), output_encoding="hex") == "1b37373331363f78151b7f2b783431333d78397828372d363c78373e783a393b3736"
     """
     That just proves that the function works, it's not actually equivalent to breaking the cipher!
     """
@@ -29,7 +31,7 @@ def test_sbXOR():
 def test_sbXOR_dec():
     ciphertext = "1b37373331363f78151b7f2b783431333d78397828372d363c78373e783a393b3736"
     key = "X"
-    assert byte_XOR_decrypt(ciphertext, hex(ord(key)), input_encoding="hex") == "Cooking MC's like a pound of bacon"
+    assert byte_XOR_decrypt(ciphertext, key.encode(), input_encoding="hex") == "Cooking MC's like a pound of bacon"
     """
     This does what it should, could the functon be refactored in terms of the encryption function?
     """


### PR DESCRIPTION
Modified the basic functions so that they would use bytes type instead of lists of hex strings. This is neater, more pythonic, and much more readable from the point of view of a 3rd party trying to reuse the code.